### PR TITLE
Add support for schema dictionnaries in `genInterface`

### DIFF
--- a/src/typeGenerator.ts
+++ b/src/typeGenerator.ts
@@ -11,7 +11,7 @@ type _ExclusiveUnion<T, K extends PropertyKey> =
 type OneOf<T> = _ExclusiveUnion<T, _AllKeys<T>>`
 
 const capFirst = (str: string) => str[0].toUpperCase() + str.slice(1)
-const jsonKey = (str: string) => str.match('\\W') ? `'${str}'` : str
+const jsonKey = (str: string) => str.match(/\W/g) ? `'${str}'` : str
 
 const refRe = /(\w+)(?:\.\w+)?#(?:\/(\w+))+/
 function simplestType (schema: Schema, interfaceName: string, stack: Stack): string {

--- a/src/typeGenerator.ts
+++ b/src/typeGenerator.ts
@@ -53,6 +53,8 @@ function genInterface (schema: Schema, interfaceName: string, stack: Stack): str
       if (propSchema.nullable) {
         str += '|null'
       }
+    } else if (propSchema.type === 'object' && typeof propSchema.additionalProperties === 'object' && Object.keys(propSchema.additionalProperties).length) {
+      str += `Record<string, ${simplestType(propSchema.additionalProperties, `${propInterfaceName}Item`, stack)}|undefined>${propSchema.nullable ? '|null' : ''}`
     } else {
       str += simplestType(propSchema, propInterfaceName, stack)
     }

--- a/src/typeGenerator.ts
+++ b/src/typeGenerator.ts
@@ -37,9 +37,10 @@ function genInterface (schema: Schema, interfaceName: string, stack: Stack): str
     if (propSchema.description) {
       str += `  /**${['', ...propSchema.description.trim().split('\n')].join('\n   * ')}\n   */\n`
     }
-    str += `  ${propSchema.readOnly ? 'readonly ' : ''}${propName}${schema.required?.includes(propName) ? '' : '?'}: `
+    const match = propName.match('\\W')
+    str += `  ${propSchema.readOnly ? 'readonly ' : ''}${match ? "'" : ''}${propName}${match ? "'" : ''}${schema.required?.includes(propName) ? '' : '?'}: `
 
-    const propInterfaceName = `${interfaceName}${capFirst(propName)}`
+    const propInterfaceName = `${interfaceName}${capFirst(propName.replace(/\W/g, ''))}`
     if (propSchema.type === 'array') {
       const itemInterfaceName = `${propInterfaceName}Item`
       if (Array.isArray(propSchema.items)) {


### PR DESCRIPTION
Modify `genInterface` to generate correct type with schema [dictionaries, hash maps and associative arrays](https://swagger.io/docs/specification/data-models/dictionaries/).

**Example :**

Adding multiples dictionaries to the `Todo` schema :
```json
"simple": {
  "type": "object",
  "additionalProperties": {
   "type": "string"
  },
  "nullable": true
},
"complex": {
  "type": "object",
  "additionalProperties": {
    "type": "object",
    "properties": {
      "text": {
        "type": "string",
        "minLength": 3,
        "maxLength": 20
      },
      "tags": {
        "type": "array",
        "nullable": true,
        "items": {
          "$ref": "defs#/definitions/tag"
        }
      }
    }
  }
},
"refDic": {
  "type": "object",
  "additionalProperties": {
    "$ref": "defs#/definitions/tag"
  }
},
"freeFormDic": {
  "type": "object",
  "additionalProperties": {}
},
"freeFormDicTwo": {
  "type": "object",
  "additionalProperties": true
},
"langs": {
  "type": "object",
  "properties": {
  "fr-FR": {
    "type": "string"
  },
  "en-US": {
    "type": "string"
  },
  "default": {
    "type": "string"
  }
  },
    "required": ["fr-FR", "en-US"],
    "additionalProperties": {
      "type": "string"
  }
}
```
output this type :
```ts
interface OaTodo {
  [...]
  simple?: Record<string, string|undefined>|null
  complex?: Record<string, OaTodoComplexItem|undefined>
  refDic?: Record<string, OaDefsTag|undefined>
  freeFormDic?: object
  freeFormDicTwo?: object
  langs?: Record<string|'fr-FR'|'en-US', string|undefined>
  [...]
}

interface OaTodoComplexItem {
  text?: string
  tags?: OaDefsTag[]|null
}
```